### PR TITLE
Add Steam Controller to simple_device_list.txt

### DIFF
--- a/conf/simple_device_list.txt
+++ b/conf/simple_device_list.txt
@@ -21,5 +21,7 @@ Nintendo RVL-CNT-01-UC
 Xbox 360 Wireless Receiver
 Microsoft X-Box 360 pad
 Mad Catz,Inc. PS3 RF pad
+Valve Software Wireless Steam Controller
+SteamController
 #ROCCAT ROCCAT Arvo
 #MOSART Semi. 2.4G Wireless Mouse


### PR DESCRIPTION
Hi proposing these changes to add Valve's own discontinued steam controller (which I have).

`Valve Software Wireless Steam Controller` is for the wireless receiver 

`SteamController` is for connected via bluetooth.