### PR TITLE
Fix to problem with controller not rebinding

### DIFF
--- a/disable_steam_input.sh
+++ b/disable_steam_input.sh
@@ -53,8 +53,9 @@ if [ ! -f "$conf_dir/disabled" ];then
       fi
       echo "$device_id" >> "$tmp_dir/controller_id.txt"
 
-    elif [ "$action" = "enable" ] && [ -f "$tmp_dir/controller_id.txt" ] && [ -n "$(grep -i "^$device_id$" "$tmp_dir/controller_id.txt")" ];then
+    elif [ "$action" = "enable" ] && [ -f "$tmp_dir/controller_id.txt" ];then
       sed -i "/^$device_id$/d" "$tmp_dir/controller_id.txt"
+      sed -i '/^$/d' "$tmp_dir/controller_id.txt"
 
       if [ ! -s "$tmp_dir/controller_id.txt" ];then
         rm "$tmp_dir/controller_id.txt"


### PR DESCRIPTION
I had issues with the controller_id.txt having blank lines that caused the controller not to rebind after unplugging the Deck hub with keyboard and mouse plugged in. Removed the grep looking for device id because that seems to be what caused it not to run the enable action. Also added a line to explicitly remove blank lines.